### PR TITLE
Added options parameter to perform_actions when you specify a directory

### DIFF
--- a/tagbak
+++ b/tagbak
@@ -60,7 +60,9 @@ class TagBak
 
   def store_tags
     datastore = []
-    files = %x{mdfind -onlyin . 'kMDItemUserTags = "*"'}.split("\n")
+    files = %x{mdfind -onlyin . 'kMDItemUserTags = "*"'}
+    files = files.encode('utf-8', 'binary', :invalid => :replace, :undef => :replace)
+    files = files.split("\n")
     files.delete_if {|file| file =~ @ignore_pattern }
 
     trap("SIGINT") { exit_cleanly }
@@ -292,13 +294,16 @@ class TagBak
   end
 
   def get_term_width
-    if ENV['COLUMNS'] =~ /^\d+$/
-      ENV['COLUMNS'].to_i
-    else
-      `tput cols`.to_i
+    begin
+      if ENV['COLUMNS'] =~ /^\d+$/
+        ENV['COLUMNS'].to_i
+      else
+        cols = `tput cols`
+        cols.length > 0 ? cols.to_i : 80
+      end
+    rescue
+      80
     end
-  rescue
-    80
   end
 
   def exit_cleanly

--- a/tagbak
+++ b/tagbak
@@ -407,7 +407,7 @@ else
     target = arg =~ /^\// ? arg : File.join(rel_base, arg)
     if File.directory? File.expand_path(target)
       base_dir = File.expand_path(target)
-      perform_action(type, base_dir)
+      perform_action(type, base_dir, options)
     else
       $stderr.puts "#{ARGV[1]} is not a directory"
       next


### PR DESCRIPTION
If you specify a directory as an argument this exception was thrown:

/Users/scott/bin/tagbak:338:in `perform_action': wrong number of arguments (2 for 3) (ArgumentError)
    from /Users/scott/bin/tagbak:410:in`block in <main>'
    from /Users/scott/bin/tagbak:406:in `each'
    from /Users/scott/bin/tagbak:406:in`<main>'
